### PR TITLE
fix: update erb and net-imap default gems to resolve Trivy CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,13 @@ RUN gem install bundler \
     # CVE-2025-61594: Update the uri default gem and remove the old gemspec
     # because `gem install` leaves it in specifications/default/
     && gem install uri -v '~> 0.13.3' \
-    && rm -f /usr/local/lib/ruby/gems/*/specifications/default/uri-*.gemspec
+    && rm -f /usr/local/lib/ruby/gems/*/specifications/default/uri-*.gemspec \
+    # CVE-2026-41316: Update the erb default gem and remove the old gemspec.
+    && gem install erb -v '~> 4.0.3.1' \
+    && rm -f /usr/local/lib/ruby/gems/*/specifications/default/erb-*.gemspec \
+    # CVE-2026-42245 / CVE-2026-42246 / CVE-2026-42257 / CVE-2026-42258:
+    # Update the net-imap default gem and remove the old gemspec.
+    && gem install net-imap -v '~> 0.4.24' \
+    && rm -f /usr/local/lib/ruby/gems/*/specifications/default/net-imap-*.gemspec
 
 RUN bundle install --gemfile=/github-script-ruby/Gemfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,11 @@ RUN gem install bundler \
     && gem install erb -v '~> 4.0.3.1' \
     && rm -f /usr/local/lib/ruby/gems/*/specifications/default/erb-*.gemspec \
     # CVE-2026-42245 / CVE-2026-42246 / CVE-2026-42257 / CVE-2026-42258:
-    # Update the net-imap default gem and remove the old gemspec.
+    # net-imap is a bundled gem (not a default gem) in Ruby 3.3, so the
+    # pre-installed copy lives in specifications/ rather than
+    # specifications/default/. `gem install` does not replace it, so
+    # uninstall the vulnerable version explicitly.
     && gem install net-imap -v '~> 0.4.24' \
-    && rm -f /usr/local/lib/ruby/gems/*/specifications/default/net-imap-*.gemspec
+    && gem uninstall net-imap --version 0.4.21 --force --executables
 
 RUN bundle install --gemfile=/github-script-ruby/Gemfile


### PR DESCRIPTION
## Summary
- Add `gem install erb -v '~> 4.0.3.1'` to `docker/Dockerfile` to replace the vulnerable default gem `erb-4.0.3`
- Add `gem install net-imap -v '~> 0.4.24'` to `docker/Dockerfile` to replace the vulnerable default gem `net-imap-0.4.21`
- Resolves CVE-2026-41316 (HIGH): ERB arbitrary code execution via deserialization
- Resolves CVE-2026-42257 / CVE-2026-42258 (CRITICAL) and CVE-2026-42245 / CVE-2026-42246 (HIGH): Net::IMAP command injection / DoS
- Fixes Trivy vulnerability scan failure observed on https://github.com/k1LoW/github-script-ruby/actions/runs/27920310891/job/82612778723

## Test plan
- [x] Verify Trivy scan job passes in CI